### PR TITLE
Fix --help output for options without a short flag (again).

### DIFF
--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -172,10 +172,10 @@ static void print_usage(const char *argv0, int ec)
 #endif
   struct option *opt = options;
   while (opt->name) {
-    if (opt->flag == NULL)
+    if (isprint(opt->val))
       fprintf(stdout, "\t -%c\t --%s\n", (char)opt->val, opt->name);
     else
-      fprintf(stdout, "\t\t --%s\n", opt->name);
+      fprintf(stdout, "\t   \t --%s\n", opt->name);
     opt++;
   }
   exit(ec);


### PR DESCRIPTION
The simulator --help output container unprintable characters for options without a short flag.
This was previously fixed in ffa591d5e09389b01c50dd98333fce6b994a11a9 but broken again in 037c835ab8a63cd5a18e407a82cc90801365394a.
This reverts the relevant lines to the upstream version.

Since this branch is regularly rebased we could optionally merge the fix with the latter commit and remove the diff from upstream entirely.
